### PR TITLE
include data when using setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,8 @@ def setup_package():
         'requires': ['numpy', 'scipy'],
         'install_requires': ['scikit-learn >= 0.16',
                            'sphinx_gallery'],
-        'setup_requires': ['numpy']
+        'setup_requires': ['numpy'],
+        'include_package_data': True
     }
 
     # Add the build_ext command only if cythonizing


### PR DESCRIPTION
Previously MANIFEST.in was ignored, python setup.py install did not install data  which was in pyearth/test