### PR TITLE
add appveyor.ml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,81 @@
+# AppVeyor.com is a Continuous Integration service to build and run tests under
+# Windows
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script interpreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\build_tools\\appveyor\\run_with_env.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "32"
+      MINICONDA: "C:\\Miniconda"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "64"
+      MINICONDA: "C:\\Miniconda-x64"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "32"
+      MINICONDA: "C:\\Miniconda35"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "64"
+      MINICONDA: "C:\\Miniconda35-x64"
+
+
+
+install:
+  # Miniconda is pre-installed in the worker build
+  - "SET PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - "python -m pip install -U pip"
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - "pip --version"
+
+  # Remove cygwin because it clashes with conda
+  # see http://help.appveyor.com/discussions/problems/3712-git-remote-https-seems-to-be-broken
+  - "rmdir C:\\cygwin /s /q"
+
+  # Install the build and runtime dependencies of the project.
+  - "conda install --quiet --yes six numpy scipy cython nose scikit-learn wheel conda-build"
+  - "pip install sphinx-gallery"
+  - "python setup.py build_ext --inplace --cythonize"
+  - "python setup.py bdist_wheel bdist_wininst"
+  - ps: "ls dist"
+  # build the conda package
+  # TODO : commented because we don't have yet a conda-recipe
+  # - "%CMD_IN_ENV% conda build build_tools/conda-recipe --quiet"
+
+  # Move the conda package into the dist directory, to register it
+  # as an "artifact" for Appveyor. cmd.exe does't have good globbing, so
+  # we'll use a simple python script.
+  # TODO : commented because we don't have yet a conda-recipe
+  # - python build_tools/move-conda-package.py build_tools/conda-recipe
+
+  # Install the generated wheel package to test it
+  - "pip install --pre --no-index --find-links dist/ py-earth"
+
+# Not a .NET project, we build scikit-learn in the install step instead
+build: false
+
+test_script:
+    # Change to a non-source folder to make sure we run the tests on the
+    #   # installed library.
+  - "mkdir empty_folder"
+  - "cd empty_folder"
+  
+  - "python -c \"import nose; nose.main()\" -s -v pyearth"
+
+    # Move back to the project folder
+  - "cd .."
+
+artifacts:
+  # Archive the generated wheel package in the ci.appveyor.com build report.
+  - path: dist\*


### PR DESCRIPTION
Issue #102, Add appveyor configuration file, based on the one used in lightnining https://github.com/scikit-learn-contrib/lightning/blob/master/appveyor.yml.

conda packaging is disabled for now, but I think will be useful to add a conda recipe. I will add an issue for this.