### PR TITLE
fix exception when dataframe labels are unicode instead of str

### DIFF
--- a/pyearth/_basis.pxd
+++ b/pyearth/_basis.pxd
@@ -91,7 +91,7 @@ cdef class ConstantBasisFunction(RootBasisFunction):
 
 cdef class VariableBasisFunction(BasisFunction):
     cdef INDEX_t variable
-    cdef str label
+    cdef label
     
     cpdef INDEX_t degree(VariableBasisFunction self)
     


### PR DESCRIPTION
the attribute label of the class VariableBasisFunction (in pyearth/_basis.pxd) is declared as str, I had an exception occuring when I was trying to fit a pandas dataframe because the type of the labels was unicode while the labels were expected to be str.