### PR TITLE
Fix sphinx doc extension error

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,7 @@ import sphinx_gallery
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-              'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig',
+              'sphinx.ext.mathjax', 'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode', 'sphinx.ext.autodoc', 'numpydoc', 'sphinx.ext.autosummary',
               'sphinxcontrib.bibtex', 'sphinx_gallery.gen_gallery']
 


### PR DESCRIPTION
I had the following error when building the doc with sphinx :

```
WARNING: sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.
Extension error:
sphinx.ext.mathjax: other math package is already loaded
make: *** [html] Error 1
```

fixed by removing sphinx.ext.pngmath 
