### PR TITLE
Make the gallery display the output of the sympy example

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -266,4 +266,6 @@ sphinx_gallery_conf = {
     # path to your examples scripts
     'examples_dirs' : '../examples',
     # path where to save gallery generated examples
-    'gallery_dirs'  : 'auto_examples'}
+    'gallery_dirs'  : 'auto_examples',
+    'filename_pattern'  : '(/plot_.*|return_.*)'
+}


### PR DESCRIPTION
The output of the sympy example `return_sympy.py` was not displayed in the gallery.