### PR TITLE
require the version of scipy to be  >= 0.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,10 @@ def setup_package():
         'py_modules': ['pyearth.earth', 'pyearth._version'],
         'classifiers': ['Development Status :: 3 - Alpha'],
         'requires': ['numpy', 'scipy'],
-        'install_requires': ['scikit-learn >= 0.16',
-                           'sphinx_gallery'],
+        'install_requires': [
+            'scipy >= 0.16',
+            'scikit-learn >= 0.16',
+            'sphinx_gallery'],
         'setup_requires': ['numpy'],
         'include_package_data': True
     }


### PR DESCRIPTION
Fix issue #138.  The minimal version of scipy should be 0.16, installing py-earth  with scipy versions from 0.13 to 0.15 triggered the same error in #137.