### PR TITLE
Fixing score_samples

### DIFF
--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -1314,7 +1314,9 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
         X, y, sample_weight, output_weight, missing = self._scrub(
             X, y, None, None, missing)
         y_hat = self.predict(X, missing=missing)
-        residual = 1 - (y - y_hat) ** 2 / y**2
+        if y_hat.ndim == 1:
+            y_hat = y_hat.reshape(-1, 1)
+        residual = 1 - (y - y_hat) ** 2 / np.var(y)
         return residual
 
     def transform(self, X, missing=None):

--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -1316,8 +1316,13 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
         y_hat = self.predict(X, missing=missing)
         if y_hat.ndim == 1:
             y_hat = y_hat.reshape(-1, 1)
-        residual = 1 - (y - y_hat) ** 2 / np.var(y)
-        return residual
+        squared_errors = (y - y_hat) ** 2
+        variances = np.var(y, axis=0).reshape(1, -1)
+        nze = variances != 0 # non-zero variance
+        nze = nze.ravel()
+        output = np.ones(squared_errors.shape)
+        output[:, nze] = 1 - squared_errors[:, nze] / variances[:, nze]
+        return output
 
     def transform(self, X, missing=None):
         '''


### PR DESCRIPTION
This version of score_samples scores each sample on a coordinate-by-coordinate basis.

It follows the internals of scikit-learn's r2_score implementation in that coordinates that have no variance are arbitrarily set to a score of 1. This prevents division by zero and -inf scores.